### PR TITLE
PNPM Fix - call ESlint bin command without node

### DIFF
--- a/src/eslint.py
+++ b/src/eslint.py
@@ -11,13 +11,6 @@ _IS_WINDOWS = sublime.platform() == 'windows'
 _ERROR_EXIT_CODE = 2
 
 
-def _get_node_path():
-    node = pathutil.find_executable(preferences.get_path(), 'node')
-    if not node:
-        raise Exception('Could not find Node.js. Check that your configuration is correct.')
-    return node
-
-
 def _get_eslint_path():
     eslint = pathutil.find_executable(preferences.get_path(), 'eslint')
     if not eslint:
@@ -30,12 +23,9 @@ def _get_command(directory, filename):
 
     local_eslint = preferences.get_local_eslint_path(directory)
     if local_eslint:
-        cmd = [_get_node_path(), local_eslint]
+        cmd = [local_eslint]
     else:
-        if _IS_WINDOWS:
-            cmd = [_get_eslint_path()]
-        else:
-            cmd = [_get_node_path(), _get_eslint_path()]
+        cmd = [_get_eslint_path()]
 
     cmd.extend([
         '--stdin',


### PR DESCRIPTION
The logic that executes the ESlint bin via explicitly using the Node executable does not work on macOS when using PNPM.  PNPM creates `node_modules/.bin` files as shell scripts.  Calling them via `node` will not work.  `.bin` files created by NPM and Yarn are Node scripts but are executable directly without needing to use the Node binary explicitly.

```
#!/usr/bin/env node

/**
 * @fileoverview Main CLI that is run via the eslint command.
 * @author Nicholas C. Zakas
 */

/* eslint no-console:off -- CLI */

"use strict";
...
```

As a result it appears that Node does not need to be called explicitly on any platform for any package manager.